### PR TITLE
Add Ghostscript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --update --no-cache \
     librsvg \
     git \
     openssh \
-    biber
+    biber \
+    ghostscript
 
 RUN apk add --update --no-cache tar curl && \
     curl -Lsf 'https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-linux.tar.gz' | tar -xvz --strip-components 1 -C /usr/local && \


### PR DESCRIPTION
This is a relatively small package, but it's required for latex documents where we need to embed pdfs, e.g the SR and Smallpeice rules.